### PR TITLE
Fix Docker deployment and benchmark test runners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,15 @@
 # BASE IMAGE AND ENVIRONMENT CONFIGURATION
 # =============================================================================
 
-# Use Ubuntu 22.04 as base image
-FROM docker.m.daocloud.io/ubuntu:22.04
+# Use the official Ubuntu 22.04 base image, optionally via a mirror.
+ARG UBUNTU_IMAGE=ubuntu:22.04
+FROM ${UBUNTU_IMAGE}
 
 # Set environment variables to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-#################### 代理设置 ####################
-# ① 如果你想在 docker build 时临时改地址，只需要
-#    docker build --build-arg PROXY=http://其他地址:端口 .
-ARG PROXY=http://192.168.1.34:7890
-
-# ② 一次性写全大小写两套环境变量，兼容所有程序
+ARG PROXY=
 ENV \
     http_proxy=${PROXY} \
     https_proxy=${PROXY} \
@@ -22,10 +18,8 @@ ENV \
     HTTP_PROXY=${PROXY} \
     HTTPS_PROXY=${PROXY} \
     FTP_PROXY=${PROXY} \
-    # 如果你的 7890 端口同时提供 SOCKS5，可以顺带写上：
-    all_proxy=socks5h://192.168.1.34:7890 \
-    ALL_PROXY=socks5h://192.168.1.34:7890 \
-    # 避免本机回环走代理
+    all_proxy=${PROXY} \
+    ALL_PROXY=${PROXY} \
     no_proxy=localhost,127.0.0.1,::1 \
     NO_PROXY=localhost,127.0.0.1,::1
 
@@ -82,6 +76,7 @@ RUN apt-get update && apt-get install -y \
 RUN python3 -m pip install --no-cache-dir \
     colored \
     numpy \
+    psutil \
     scipy \
     scikit-learn
 

--- a/engines/hyperscan/Makefile
+++ b/engines/hyperscan/Makefile
@@ -23,6 +23,7 @@ clean:
 	rm -rf $(BINDIR)
 
 test: $(TARGET)
+	chmod +x $(TEST_DIR)/run_tests.sh 2>/dev/null || true
 	cd $(TEST_DIR) && ./run_tests.sh
 
 .DEFAULT_GOAL := all 

--- a/engines/nodejs21/tests/v8_engine_test.sh
+++ b/engines/nodejs21/tests/v8_engine_test.sh
@@ -11,6 +11,10 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE_DIR="$(dirname "$SCRIPT_DIR")"
+TEST_FILE="$ENGINE_DIR/test-linear.js"
+
 # Function to run V8 engine tests
 run_v8_test() {
     local test_name="$1"
@@ -23,15 +27,15 @@ run_v8_test() {
     result=""
     exit_code=1
     
-    if [ -f "test-linear.js" ]; then
+    if [ -f "$TEST_FILE" ]; then
         if [ -n "$node_flags" ]; then
-            result=$(node $node_flags test-linear.js 2>&1)
+            result=$(node $node_flags "$TEST_FILE" 2>&1)
         else
-            result=$(node test-linear.js 2>&1)
+            result=$(node "$TEST_FILE" 2>&1)
         fi
         exit_code=$?
     else
-        result="test-linear.js not found"
+        result="test-linear.js not found at $TEST_FILE"
         exit_code=1
     fi
     

--- a/engines/re2/Makefile
+++ b/engines/re2/Makefile
@@ -27,6 +27,7 @@ clean:
 	rm -rf $(BIN_DIR)
 
 test: $(TARGET)
+	chmod +x $(TEST_DIR)/run_tests.sh 2>/dev/null || true
 	cd $(TEST_DIR) && ./run_tests.sh
 
 .PHONY: install-deps


### PR DESCRIPTION
## Summary
- make the Docker base image configurable via `UBUNTU_IMAGE` and remove the hard-coded local proxy defaults
- add the missing `psutil` dependency required by `Gen.py` and `Verify.py`
- fix test runner permissions for the `hyperscan` and `re2` engines
- fix the Node.js 21 V8 test script so it resolves `test-linear.js` from the engine directory

## Validation
- built the Docker image successfully as `benchmark-test`
- ran `cd /app/engines && ./run_all_tests.sh` inside the container: `Passed: 19`, `Failed: 0`
- ran `cd /app/engines/nodejs21 && make v8-test`: `Passed: 3/3`
- verified `python3 Gen.py --help` and `python3 Verify.py --help`
- smoke-tested `tools/GREWIA/run.py`
