### PR TITLE
Require cgroup-backed runexec for the web service

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -474,7 +474,7 @@ timeout 10 docker run --rm -v /tmp:/tmp redos-test \
 
 ```bash
 # 启动容器并映射端口 8080
-docker run --rm -p 8080:8080 -v /tmp:/tmp redos-test
+docker run --rm --privileged --cgroupns=host -p 8080:8080 -v /tmp:/tmp redos-test
 ```
 
 然后打开浏览器访问 `http://localhost:8080`：
@@ -984,7 +984,7 @@ jobs:
 - 复制 `benchexec/` 至 `/app/benchexec`（供 `bin/runexec` 使用）。
 - 复制 `init.sh` 到容器根目录并设为 `ENTRYPOINT`：
   - `init.sh` 会创建 `/sys/fs/cgroup/init` 与 `/sys/fs/cgroup/benchexec`，并把所有 `cgroup.controllers` 中的控制器写入它们对应的 `cgroup.subtree_control`，使子树可用。
-- 服务器端默认走 runexec 的容器模式（可通过 `RUNEXEC_NO_CONTAINER=1` 切回非容器模式，仅用于应急）。
+- 服务器端强制走 runexec 的容器模式；如果 cgroups v2 未正确启用，服务会在启动时直接报错退出，不再自动回退。
 
 2) 运行容器（Docker）
 
@@ -992,14 +992,14 @@ jobs:
 
 ```bash
 docker run -d --name redos-web \
-  --privileged --cap-drop=all \
+  --privileged --cgroupns=host \
   -p 8080:8080 \
   -v /tmp:/tmp \
   redos-test
 ```
 
 说明：
-- `--privileged --cap-drop=all` 是 BenchExec 文档推荐的简化方式（生产更推荐 Podman rootless）。
+- `--privileged --cgroupns=host` 可确保容器内能写入并委派 cgroups v2 子树，供 BenchExec `runexec` 施加时间/内存/核心限制。
 - 如果你要热替换前端静态资源，可额外挂载 `-v $(pwd)/public:/app/public`。
 
 3) 验证 cgroups 子树是否启用
@@ -1016,9 +1016,15 @@ docker exec -it redos-web sh -lc 'cat /sys/fs/cgroup/cgroup.controllers; echo "-
 
 runexec 的目录参数不可对同一路径同时指定多种模式。项目内封装已避免 `/tmp` 被重复声明（保留 `--full-access-dir /tmp`）。若你在外部脚本中调用 runexec，请避免同时对 `/tmp` 使用 `--hidden-dir` 与 `--full-access-dir`。
 
-5) 非容器模式（不推荐）
+5) 失败策略
 
-设置 `RUNEXEC_NO_CONTAINER=1` 环境变量会启用 runexec 的非容器模式，仅用于 Docker Desktop/某些宿主上暂时绕过 cgroup 限制的场景。此模式下不保证时间/内存限制能可靠生效。
+当前版本不再提供 `RUNEXEC_NO_CONTAINER=1` 之类的非容器回退模式。若 cgroups v2 没有正确启用，服务会给出明确错误，例如：
+
+- `/sys/fs/cgroup is mounted read-only`
+- `Required controller 'memory' is missing`
+- `/sys/fs/cgroup/benchexec/cgroup.subtree_control is not writable`
+
+这种设计是为了保证资源限制一定由 BenchExec + cgroups 实施，而不是在限制失效时静默退回普通执行。
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV TZ=UTC
 #################### 代理设置 ####################
 # 如果你想在 docker build 时临时改地址，可使用：
 #    docker build --build-arg PROXY=http://其他地址:端口 .
-ARG PROXY=http://192.168.1.34:7890
+ARG PROXY=
 
 # 一次性写全大小写两套环境变量，兼容所有程序
 ENV \
@@ -24,8 +24,8 @@ ENV \
     HTTP_PROXY=${PROXY} \
     HTTPS_PROXY=${PROXY} \
     FTP_PROXY=${PROXY} \
-    all_proxy=socks5h://192.168.1.34:7890 \
-    ALL_PROXY=socks5h://192.168.1.34:7890 \
+    all_proxy=${PROXY} \
+    ALL_PROXY=${PROXY} \
     no_proxy=localhost,127.0.0.1,::1 \
     NO_PROXY=localhost,127.0.0.1,::1
 
@@ -173,10 +173,11 @@ COPY init.sh /init.sh
 RUN chmod +x /init.sh
 COPY benchexec/ /app/benchexec/
 
-# Ensure Node.js binaries are available system-wide for engines without relying on NVM in /home
-RUN ln -sf /home/developer/.nvm/versions/node/v14.21.3/bin/node /usr/local/bin/node14 \
- && ln -sf /home/developer/.nvm/versions/node/v21.7.3/bin/node /usr/local/bin/node21 \
- && ln -sf /home/developer/.nvm/versions/node/v21.7.3/bin/node /usr/local/bin/node || true
+# Ensure Node.js binaries are available system-wide without depending on /home paths.
+# BenchExec container mode may isolate /home, so copy the actual binaries instead of symlinking.
+RUN install -m 0755 /home/developer/.nvm/versions/node/v14.21.3/bin/node /usr/local/bin/node14 \
+ && install -m 0755 /home/developer/.nvm/versions/node/v21.7.3/bin/node /usr/local/bin/node21 \
+ && install -m 0755 /home/developer/.nvm/versions/node/v21.7.3/bin/node /usr/local/bin/node
 
 # Change ownership to developer
 RUN chown -R developer:developer /app
@@ -196,4 +197,3 @@ EXPOSE 8080
 USER root
 ENTRYPOINT ["/init.sh"]
 CMD ["npm", "start"]
-

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run --rm --privileged --cgroupns=host -p 8080:8080 -v /tmp:/tmp redos-tes
 
 在网页中可以勾选需要的工具和引擎，先运行“检测工具”阶段获取攻击字符串，再选择其中一个结果进入“引擎验证”阶段。
 如需快速自检，可运行 `npm run test:e2e`（基于 Playwright 的模拟端到端测试，默认使用 mock 运行器，不会真正触发真实工具或引擎）。
-如果你需要容器内真正启用 BenchExec `runexec` 的 cgroups/时间内存限制，请使用 `--privileged --cgroupns=host`。普通 `docker run` 在很多环境里会把 `/sys/fs/cgroup` 以只读方式挂进容器，导致限制无法可靠生效。
+如果你需要容器内真正启用 BenchExec `runexec` 的 cgroups/时间内存限制，请使用 `--privileged --cgroupns=host`。普通 `docker run` 在很多环境里会把 `/sys/fs/cgroup` 以只读方式挂进容器；当前版本不会再自动回退，而是直接以明确报错退出。
 
 ### 核心特性
 
@@ -109,7 +109,7 @@ docker run --rm --privileged --cgroupns=host -p 8080:8080 -v /tmp:/tmp redos-tes
 
 The dashboard lets you run detection tools in parallel, pick a generated payload, and then benchmark it against the selected engines with live progress updates.
 To sanity-check the UI workflow without hitting real binaries, run `npm run test:e2e`; this launches a Playwright test suite backed by mocked tool/engine runners.
-If you need BenchExec `runexec` with real cgroup-based resource limits inside Docker, start the container with `--privileged --cgroupns=host`. On many hosts, a plain `docker run` mounts `/sys/fs/cgroup` read-only and BenchExec cannot enforce limits reliably.
+If you need BenchExec `runexec` with real cgroup-based resource limits inside Docker, start the container with `--privileged --cgroupns=host`. On many hosts, a plain `docker run` mounts `/sys/fs/cgroup` read-only; this version no longer falls back automatically and will fail fast with an explicit error instead.
 
 ##### 资源限制与 API（Resource Limits & API）
 
@@ -349,7 +349,7 @@ Issues and pull requests are welcome for bug reports and improvements.
 This project is refactored from the original ReDoS testing environment and follows the original licenses of each tool and engine.
 ### Resource limits (BenchExec runexec)
 
-- 网页中“检测工具”和“引擎验证”已支持为每次运行设置资源限制：运行时间（秒）、核心数、内存（MB）。
-- 后端通过 BenchExec 的 unexec 对应参数（--timelimit/--walltimelimit、--cores、--memlimit）进行强制限制。
-- 本仓库默认在容器内路径 /app/benchexec 提供 unexec（由工作区 enchexec/ 目录拷入）。如需在 Docker 中启用 cgroups/绑核，请参考 enchexec/examples/runexec-in-docker-quickstart.md，建议在受控环境中使用 --privileged 或按 BenchExec 文档配置 Podman rootless。
-- 若 unexec 不可用，强制限制将无法生效并可能导致任务失败，请确保容器内 Python3 可用且存在 /app/benchexec/bin/runexec。
+- The web UI supports per-run limits for tool detection and engine verification: timeout in seconds, CPU cores, and memory in MB.
+- The backend enforces these limits with BenchExec `runexec` parameters such as `--timelimit`, `--walltimelimit`, `--cores`, and `--memlimit`.
+- This repository bundles BenchExec at `/app/benchexec`. To use it correctly in Docker, start the service with `--privileged --cgroupns=host`.
+- This version does not fall back to non-cgroup execution. If cgroups are not available, the service fails fast with an explicit error message.

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ cat /tmp/test.json
 
 ```bash
 # 启动容器并开放Web端口
-docker run --rm -p 8080:8080 -v /tmp:/tmp redos-test
+docker run --rm --privileged --cgroupns=host -p 8080:8080 -v /tmp:/tmp redos-test
 
 # 浏览器访问 http://localhost:8080 进入图形化界面
 ```
 
 在网页中可以勾选需要的工具和引擎，先运行“检测工具”阶段获取攻击字符串，再选择其中一个结果进入“引擎验证”阶段。
 如需快速自检，可运行 `npm run test:e2e`（基于 Playwright 的模拟端到端测试，默认使用 mock 运行器，不会真正触发真实工具或引擎）。
+如果你需要容器内真正启用 BenchExec `runexec` 的 cgroups/时间内存限制，请使用 `--privileged --cgroupns=host`。普通 `docker run` 在很多环境里会把 `/sys/fs/cgroup` 以只读方式挂进容器，导致限制无法可靠生效。
 
 ### 核心特性
 
@@ -101,13 +102,14 @@ docker run --rm -v /tmp:/tmp redos-test \
 
 ```bash
 # Launch the container with the dashboard
-docker run --rm -p 8080:8080 -v /tmp:/tmp redos-test
+docker run --rm --privileged --cgroupns=host -p 8080:8080 -v /tmp:/tmp redos-test
 
 # Open http://localhost:8080 in your browser
 ```
 
 The dashboard lets you run detection tools in parallel, pick a generated payload, and then benchmark it against the selected engines with live progress updates.
 To sanity-check the UI workflow without hitting real binaries, run `npm run test:e2e`; this launches a Playwright test suite backed by mocked tool/engine runners.
+If you need BenchExec `runexec` with real cgroup-based resource limits inside Docker, start the container with `--privileged --cgroupns=host`. On many hosts, a plain `docker run` mounts `/sys/fs/cgroup` read-only and BenchExec cannot enforce limits reliably.
 
 ##### 资源限制与 API（Resource Limits & API）
 
@@ -116,6 +118,7 @@ To sanity-check the UI workflow without hitting real binaries, run `npm run test
   - `POST /api/jobs/tools`：接受 `regex`, `tools[]`，可选 `timeoutSeconds`, `cpuCores`, `memoryMB`
   - `POST /api/jobs/engines`：接受 `regex`, `engines[]`, `attack{prefix,infix,suffix,repeat_times}`, 可选 `matchMode`, `repeatOverride`, `maxAttackLength`, 以及 `timeoutSeconds`, `cpuCores`, `memoryMB`
 - 容器内通过 BenchExec `runexec` 施加限制。请确保 cgroups v2 子树 controller 已在容器中启用（详见 DEPLOYMENT.md 的“Runexec & cgroups v2（容器模式）”）。
+- 若要让这些限制在 Docker 中可靠生效，建议使用 `docker run --privileged --cgroupns=host ...` 启动 Web 服务。
 
 ### 项目结构
 

--- a/init.sh
+++ b/init.sh
@@ -1,34 +1,69 @@
 #!/bin/sh
 set -eu
 
-# Prepare cgroups v2 subtree for BenchExec inside this container.
-# This follows benchexec/doc/benchexec-in-container.md (non-systemd, cgroups v2).
+fail_cgroup() {
+  echo "FATAL: BenchExec requires writable cgroups v2 inside the container." >&2
+  echo "FATAL: $1" >&2
+  echo "FATAL: Start the service with: docker run --rm --privileged --cgroupns=host -p 8080:8080 -v /tmp:/tmp redos-test" >&2
+  exit 1
+}
 
-# Some distros mount cgroup2 read-only by default; require --privileged for this to work.
+needs_benchexec_cgroups() {
+  if [ "${1:-}" = "npm" ] && [ "${2:-}" = "start" ]; then
+    return 0
+  fi
+  if [ "${1:-}" = "node" ] && [ "${2:-}" = "server/index.js" ]; then
+    return 0
+  fi
+  return 1
+}
 
-# init：用于把当前 PID（容器内的 PID 1）迁移进去，从而“释放”根 cgroup 以便做委派（delegation）
-# benchexec：作为 runexec 的工作子树，使用--no-container模式，后续 runexec 会严格在此之下创建自己的 cgroup
-mkdir -p /sys/fs/cgroup/init /sys/fs/cgroup/benchexec || true
+if needs_benchexec_cgroups "$@"; then
+  cgroup_mount="$(awk '$2=="/sys/fs/cgroup"{print $3" "$4; exit}' /proc/mounts)"
+  [ -n "$cgroup_mount" ] || fail_cgroup "/sys/fs/cgroup is not mounted in the container."
 
+  cgroup_fs="$(printf '%s' "$cgroup_mount" | cut -d' ' -f1)"
+  cgroup_opts="$(printf '%s' "$cgroup_mount" | cut -d' ' -f2-)"
+  [ "$cgroup_fs" = "cgroup2" ] || fail_cgroup "/sys/fs/cgroup is mounted as '$cgroup_fs', expected cgroup2."
 
-# Move this init process into its own cgroup to free up the root for delegation
-if [ -w /sys/fs/cgroup/init/cgroup.procs ]; then
-  echo $$ > /sys/fs/cgroup/init/cgroup.procs || true # $$ 是当前 shell 的 PID（在容器中通常是 PID 1），把当前进程移出根 cgroup，释放根 cgroup 用于“只承载子 cgroup（而非进程）”的委派模式
-fi
+  case ",$cgroup_opts," in
+    *,rw,*) ;;
+    *) fail_cgroup "/sys/fs/cgroup is mounted read-only with options '$cgroup_opts'." ;;
+  esac
 
+  controllers="$(cat /sys/fs/cgroup/cgroup.controllers 2>/dev/null || true)"
+  [ -n "$controllers" ] || fail_cgroup "Cannot read /sys/fs/cgroup/cgroup.controllers."
 
-# Enable all controllers on the root and on the benchexec subtree
-if [ -r /sys/fs/cgroup/cgroup.controllers ]; then
-  for controller in $(cat /sys/fs/cgroup/cgroup.controllers); do #cgroups v2 根目录下的 cgroup.controllers 列出当前内核可用的控制器（例如 cpu memory cpuset pids io ...）。只有在父节点的 cgroup.subtree_control 里显式 + 开启，子 cgroup 才能使用对应控制器。
-    # 开启根 cgroup 和 benchexec 子树的所有控制器
-    if [ -w /sys/fs/cgroup/cgroup.subtree_control ]; then
-      echo +$controller > /sys/fs/cgroup/cgroup.subtree_control || true
-    fi
-    if [ -w /sys/fs/cgroup/benchexec/cgroup.subtree_control ]; then
-      echo +$controller > /sys/fs/cgroup/benchexec/cgroup.subtree_control || true
-    fi
+  for required in cpu memory pids; do
+    printf '%s\n' "$controllers" | grep -qw "$required" || \
+      fail_cgroup "Required controller '$required' is missing. Available controllers: $controllers"
+  done
+
+  mkdir -p /sys/fs/cgroup/init /sys/fs/cgroup/benchexec || \
+    fail_cgroup "Failed to create /sys/fs/cgroup/init or /sys/fs/cgroup/benchexec."
+
+  [ -w /sys/fs/cgroup/init/cgroup.procs ] || \
+    fail_cgroup "/sys/fs/cgroup/init/cgroup.procs is not writable."
+  echo $$ > /sys/fs/cgroup/init/cgroup.procs || \
+    fail_cgroup "Failed to move PID 1 into /sys/fs/cgroup/init/cgroup.procs."
+
+  [ -w /sys/fs/cgroup/cgroup.subtree_control ] || \
+    fail_cgroup "/sys/fs/cgroup/cgroup.subtree_control is not writable."
+  [ -w /sys/fs/cgroup/benchexec/cgroup.subtree_control ] || \
+    fail_cgroup "/sys/fs/cgroup/benchexec/cgroup.subtree_control is not writable."
+
+  for controller in $controllers; do
+    echo "+$controller" > /sys/fs/cgroup/cgroup.subtree_control || \
+      fail_cgroup "Failed to enable controller '$controller' in /sys/fs/cgroup/cgroup.subtree_control."
+    echo "+$controller" > /sys/fs/cgroup/benchexec/cgroup.subtree_control || \
+      fail_cgroup "Failed to enable controller '$controller' in /sys/fs/cgroup/benchexec/cgroup.subtree_control."
+  done
+
+  enabled="$(cat /sys/fs/cgroup/benchexec/cgroup.subtree_control 2>/dev/null || true)"
+  for required in cpu memory pids; do
+    printf '%s\n' "$enabled" | grep -qw "$required" || \
+      fail_cgroup "Controller '$required' was not enabled under /sys/fs/cgroup/benchexec/cgroup.subtree_control."
   done
 fi
 
 exec "$@"
-

--- a/quick_verify.sh
+++ b/quick_verify.sh
@@ -22,12 +22,12 @@ fail_count=0
 echo -n "1. Checking Docker image... "
 if docker images | grep -q "redos-test"; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${RED}✗${NC}"
     echo "   Error: Docker image 'redos-test' not found"
     echo "   Run: docker build --rm -t redos-test ."
-    ((fail_count++))
+    ((fail_count+=1))
     exit 1
 fi
 
@@ -35,11 +35,11 @@ fi
 echo -n "2. Testing container startup... "
 if docker run --rm redos-test echo "test" > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${RED}✗${NC}"
     echo "   Error: Container failed to start"
-    ((fail_count++))
+    ((fail_count+=1))
     exit 1
 fi
 
@@ -47,20 +47,20 @@ fi
 echo -n "3. Checking tools directory... "
 if docker run --rm redos-test test -d /app/tools > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${RED}✗${NC}"
-    ((fail_count++))
+    ((fail_count+=1))
 fi
 
 # Test 4: Engines directory exists
 echo -n "4. Checking engines directory... "
 if docker run --rm redos-test test -d /app/engines > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${RED}✗${NC}"
-    ((fail_count++))
+    ((fail_count+=1))
 fi
 
 # Test 5: regexploit tool
@@ -69,11 +69,11 @@ SAFE_REGEX_B64="XmFiYyQ="  # ^abc$
 if timeout 30 docker run --rm -v /tmp:/tmp redos-test \
     python3 /app/tools/regexploit/run.py "$SAFE_REGEX_B64" /tmp/verify_regexploit.json > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${RED}✗${NC}"
     echo "   Error: regexploit tool failed"
-    ((fail_count++))
+    ((fail_count+=1))
 fi
 
 # Test 6: regexstatic tool
@@ -81,7 +81,7 @@ echo -n "6. Testing regexstatic tool... "
 if timeout 30 docker run --rm -v /tmp:/tmp redos-test \
     python3 /app/tools/regexstatic/run.py "$SAFE_REGEX_B64" /tmp/verify_regexstatic.json > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${YELLOW}⚠${NC} (may timeout, this is acceptable)"
     # Not counting as failure
@@ -93,14 +93,14 @@ echo "abc" > /tmp/verify_engine_input.txt
 if timeout 10 docker run --rm -v /tmp:/tmp redos-test \
     /app/engines/python/bin/benchmark "$SAFE_REGEX_B64" /tmp/verify_engine_input.txt 1 > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${YELLOW}⚠${NC} (may timeout, checking file exists)"
     if docker run --rm redos-test test -f /app/engines/python/bin/benchmark; then
         echo "   Binary exists, considering as pass"
-        ((success_count++))
+        ((success_count+=1))
     else
-        ((fail_count++))
+        ((fail_count+=1))
     fi
 fi
 
@@ -113,13 +113,13 @@ for tool in "${tools[@]}"; do
         all_exist=false
         echo -e "${RED}✗${NC}"
         echo "   Missing: $tool"
-        ((fail_count++))
+        ((fail_count+=1))
         break
     fi
 done
 if $all_exist; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 fi
 
 # Test 9: Check critical engines exist
@@ -131,28 +131,28 @@ for engine in "${engines[@]}"; do
         all_exist=false
         echo -e "${RED}✗${NC}"
         echo "   Missing: $engine"
-        ((fail_count++))
+        ((fail_count+=1))
         break
     fi
 done
 if $all_exist; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 fi
 
 # Test 10: Python dependencies
 echo -n "10. Checking Python dependencies... "
 if docker run --rm redos-test python3 -c "import numpy; import scipy; import sklearn" > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC}"
-    ((success_count++))
+    ((success_count+=1))
 else
     echo -e "${RED}✗${NC}"
     echo "   Error: Python dependencies missing (numpy, scipy, scikit-learn)"
-    ((fail_count++))
+    ((fail_count+=1))
 fi
 
 # Cleanup
-rm -f /tmp/verify_*.json /tmp/verify_engine_input.txt 2>/dev/null
+rm -f /tmp/verify_*.json /tmp/verify_engine_input.txt 2>/dev/null || true
 
 echo ""
 echo "==================================="

--- a/server/engine-runner.js
+++ b/server/engine-runner.js
@@ -1,10 +1,6 @@
 const fs = require('fs/promises');
 const os = require('os');
 const path = require('path');
-const util = require('util');
-const childProcess = require('child_process');
-
-const execFile = util.promisify(childProcess.execFile);
 
 const { ENGINE_DEFINITIONS, DEFAULT_OPTIONS } = require('./definitions');
 const { runWithRunexec } = require('./runexec');
@@ -158,65 +154,27 @@ async function executeEngine(engineId, payloadPath, regexBase64, matchMode, time
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `redos-engine-${engineId}-`));
   const programOutputPath = path.join(tempDir, 'output.log');
   let allocated = null;
-  let runexecFallbackLogs = [];
-  const useRunexec = process.env.DISABLE_RUNEXEC !== '1';
   try {
     if (cpuAllocator && Number.isFinite(cpuCores) && cpuCores > 0) {
       allocated = await cpuAllocator.acquire(cpuCores);
     }
-    if (useRunexec) {
-      try {
-        await runWithRunexec({
-          cmd: binaryPath,
-          args: [regexBase64, payloadPath, String(matchMode)],
-          cwd: path.dirname(binaryPath),
-          env: {
-            PATH: `${process.env.PATH || ''}:/usr/local/bin:/home/developer/.nvm/versions/node/v21.7.3/bin:/home/developer/.nvm/versions/node/v14.21.3/bin`
-          },
-          outputLogPath: programOutputPath,
-          timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-          walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-          memoryMB,
-          cores: allocated?.cores
-        });
-        let stdout = '';
-        try { stdout = await fs.readFile(programOutputPath, 'utf8'); } catch {}
-        const stderr = '';
-        return { stdout, stderr, runexecFallbackLogs };
-      } catch (error) {
-        if (error.code !== 'RUNEXEC_UNAVAILABLE') {
-          throw error;
-        }
-        runexecFallbackLogs = [
-          ...error.stdout ? [{ stream: 'stderr', content: clampLog(error.stdout) }] : [],
-          ...error.stderr ? [{ stream: 'stderr', content: clampLog(error.stderr) }] : []
-        ];
-      }
-    } else {
-      const execOptions = {
-        cwd: path.dirname(binaryPath),
-        env: {
-          ...process.env,
-          PATH: `${process.env.PATH || ''}:/usr/local/bin:/home/developer/.nvm/versions/node/v21.7.3/bin:/home/developer/.nvm/versions/node/v14.21.3/bin`
-        },
-        timeout: timeoutMs,
-        maxBuffer: 20 * 1024 * 1024
-      };
-      const result = await execFile(binaryPath, [regexBase64, payloadPath, String(matchMode)], execOptions);
-      return { stdout: result.stdout || '', stderr: result.stderr || '', runexecFallbackLogs };
-    }
-
-    const execOptions = {
+    await runWithRunexec({
+      cmd: binaryPath,
+      args: [regexBase64, payloadPath, String(matchMode)],
       cwd: path.dirname(binaryPath),
       env: {
-        ...process.env,
         PATH: `${process.env.PATH || ''}:/usr/local/bin:/home/developer/.nvm/versions/node/v21.7.3/bin:/home/developer/.nvm/versions/node/v14.21.3/bin`
       },
-      timeout: timeoutMs,
-      maxBuffer: 20 * 1024 * 1024
-    };
-    const result = await execFile(binaryPath, [regexBase64, payloadPath, String(matchMode)], execOptions);
-    return { stdout: result.stdout || '', stderr: result.stderr || '', runexecFallbackLogs };
+      outputLogPath: programOutputPath,
+      timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+      walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+      memoryMB,
+      cores: allocated?.cores
+    });
+    let stdout = '';
+    try { stdout = await fs.readFile(programOutputPath, 'utf8'); } catch {}
+    const stderr = '';
+    return { stdout, stderr };
   } finally {
     try { allocated?.release(); } catch {}
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -311,7 +269,6 @@ async function runEnginesJob(
           raw: result.stdout?.trim() || ''
         },
         logs: [
-          ...result.runexecFallbackLogs,
           ...result.stdout ? [{ stream: 'stdout', content: clampLog(result.stdout) }] : [],
           ...result.stderr ? [{ stream: 'stderr', content: clampLog(result.stderr) }] : []
         ]

--- a/server/engine-runner.js
+++ b/server/engine-runner.js
@@ -158,29 +158,40 @@ async function executeEngine(engineId, payloadPath, regexBase64, matchMode, time
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `redos-engine-${engineId}-`));
   const programOutputPath = path.join(tempDir, 'output.log');
   let allocated = null;
+  let runexecFallbackLogs = [];
   const useRunexec = process.env.DISABLE_RUNEXEC !== '1';
   try {
     if (cpuAllocator && Number.isFinite(cpuCores) && cpuCores > 0) {
       allocated = await cpuAllocator.acquire(cpuCores);
     }
     if (useRunexec) {
-      await runWithRunexec({
-        cmd: binaryPath,
-        args: [regexBase64, payloadPath, String(matchMode)],
-        cwd: path.dirname(binaryPath),
-        env: {
-          PATH: `${process.env.PATH || ''}:/usr/local/bin:/home/developer/.nvm/versions/node/v21.7.3/bin:/home/developer/.nvm/versions/node/v14.21.3/bin`
-        },
-        outputLogPath: programOutputPath,
-        timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-        walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-        memoryMB,
-        cores: allocated?.cores
-      });
-      let stdout = '';
-      try { stdout = await fs.readFile(programOutputPath, 'utf8'); } catch {}
-      const stderr = '';
-      return { stdout, stderr };
+      try {
+        await runWithRunexec({
+          cmd: binaryPath,
+          args: [regexBase64, payloadPath, String(matchMode)],
+          cwd: path.dirname(binaryPath),
+          env: {
+            PATH: `${process.env.PATH || ''}:/usr/local/bin:/home/developer/.nvm/versions/node/v21.7.3/bin:/home/developer/.nvm/versions/node/v14.21.3/bin`
+          },
+          outputLogPath: programOutputPath,
+          timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+          walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+          memoryMB,
+          cores: allocated?.cores
+        });
+        let stdout = '';
+        try { stdout = await fs.readFile(programOutputPath, 'utf8'); } catch {}
+        const stderr = '';
+        return { stdout, stderr, runexecFallbackLogs };
+      } catch (error) {
+        if (error.code !== 'RUNEXEC_UNAVAILABLE') {
+          throw error;
+        }
+        runexecFallbackLogs = [
+          ...error.stdout ? [{ stream: 'stderr', content: clampLog(error.stdout) }] : [],
+          ...error.stderr ? [{ stream: 'stderr', content: clampLog(error.stderr) }] : []
+        ];
+      }
     } else {
       const execOptions = {
         cwd: path.dirname(binaryPath),
@@ -192,8 +203,20 @@ async function executeEngine(engineId, payloadPath, regexBase64, matchMode, time
         maxBuffer: 20 * 1024 * 1024
       };
       const result = await execFile(binaryPath, [regexBase64, payloadPath, String(matchMode)], execOptions);
-      return { stdout: result.stdout || '', stderr: result.stderr || '' };
+      return { stdout: result.stdout || '', stderr: result.stderr || '', runexecFallbackLogs };
     }
+
+    const execOptions = {
+      cwd: path.dirname(binaryPath),
+      env: {
+        ...process.env,
+        PATH: `${process.env.PATH || ''}:/usr/local/bin:/home/developer/.nvm/versions/node/v21.7.3/bin:/home/developer/.nvm/versions/node/v14.21.3/bin`
+      },
+      timeout: timeoutMs,
+      maxBuffer: 20 * 1024 * 1024
+    };
+    const result = await execFile(binaryPath, [regexBase64, payloadPath, String(matchMode)], execOptions);
+    return { stdout: result.stdout || '', stderr: result.stderr || '', runexecFallbackLogs };
   } finally {
     try { allocated?.release(); } catch {}
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -288,6 +311,7 @@ async function runEnginesJob(
           raw: result.stdout?.trim() || ''
         },
         logs: [
+          ...result.runexecFallbackLogs,
           ...result.stdout ? [{ stream: 'stdout', content: clampLog(result.stdout) }] : [],
           ...result.stderr ? [{ stream: 'stderr', content: clampLog(result.stderr) }] : []
         ]
@@ -323,4 +347,3 @@ module.exports = {
   runEnginesJob,
   buildAttackPayload
 };
-

--- a/server/job-manager.js
+++ b/server/job-manager.js
@@ -119,6 +119,7 @@ class JobManager {
         res.flush();
       }
     }, 15000);
+    heartbeat.unref?.();
 
     res.on('close', () => {
       clearInterval(heartbeat);

--- a/server/runexec.js
+++ b/server/runexec.js
@@ -9,6 +9,13 @@ const execFile = util.promisify(childProcess.execFile);
 const { PROJECT_ROOT } = require('./definitions');
 const { coresToSpec } = require('./cpu-allocator');
 
+const RUNEXEC_FALLBACK_PATTERNS = [
+  'Creating namespace for container mode failed',
+  'Operation not permitted',
+  'cgroupfs is mounted read-only',
+  'Cannot reliably kill sub-processes without freezer cgroup or container mode'
+];
+
 function parseRunexecResult(stdout) {
   const result = {};
   const lines = String(stdout || '').split(/\r?\n/);
@@ -19,6 +26,11 @@ function parseRunexecResult(stdout) {
     }
   }
   return result;
+}
+
+function isRunexecUnavailableOutput(stdout, stderr) {
+  const text = `${stdout || ''}\n${stderr || ''}`;
+  return RUNEXEC_FALLBACK_PATTERNS.some(pattern => text.includes(pattern));
 }
 
 function memMbToArg(memoryMB) {
@@ -83,12 +95,39 @@ async function runWithRunexec({
     maxBuffer: 20 * 1024 * 1024
   };
 
-  const { stdout, stderr } = await execFile(pythonBin, [runexecPath, ...ra], execOptions);
+  let stdout = '';
+  let stderr = '';
+  try {
+    const result = await execFile(pythonBin, [runexecPath, ...ra], execOptions);
+    stdout = result.stdout || '';
+    stderr = result.stderr || '';
+  } catch (error) {
+    stdout = error.stdout || '';
+    stderr = error.stderr || '';
+    if (isRunexecUnavailableOutput(stdout, stderr)) {
+      const fallbackError = new Error('runexec is unavailable in the current container environment');
+      fallbackError.code = 'RUNEXEC_UNAVAILABLE';
+      fallbackError.stdout = stdout;
+      fallbackError.stderr = stderr;
+      throw fallbackError;
+    }
+    throw error;
+  }
+
   const parsed = parseRunexecResult(stdout);
+  if ((parsed.terminationreason === 'failed' || parsed.terminationreason === 'killed')
+      && isRunexecUnavailableOutput(stdout, stderr)) {
+    const fallbackError = new Error('runexec is unavailable in the current container environment');
+    fallbackError.code = 'RUNEXEC_UNAVAILABLE';
+    fallbackError.stdout = stdout;
+    fallbackError.stderr = stderr;
+    fallbackError.parsed = parsed;
+    throw fallbackError;
+  }
+
   return { stdout, stderr, parsed };
 }
 
 module.exports = {
   runWithRunexec
 };
-

--- a/server/runexec.js
+++ b/server/runexec.js
@@ -1,5 +1,5 @@
-﻿const fs = require('fs/promises');
-const os = require('os');
+﻿const fsSync = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 const util = require('util');
 const childProcess = require('child_process');
@@ -9,12 +9,14 @@ const execFile = util.promisify(childProcess.execFile);
 const { PROJECT_ROOT } = require('./definitions');
 const { coresToSpec } = require('./cpu-allocator');
 
-const RUNEXEC_FALLBACK_PATTERNS = [
+const RUNEXEC_ENV_PATTERNS = [
   'Creating namespace for container mode failed',
   'Operation not permitted',
   'cgroupfs is mounted read-only',
   'Cannot reliably kill sub-processes without freezer cgroup or container mode'
 ];
+const REQUIRED_CONTROLLERS = ['cpu', 'memory', 'pids'];
+const RUNEXEC_HINT = 'Start the container with: docker run --rm --privileged --cgroupns=host -p 8080:8080 -v /tmp:/tmp redos-test';
 
 function parseRunexecResult(stdout) {
   const result = {};
@@ -28,9 +30,112 @@ function parseRunexecResult(stdout) {
   return result;
 }
 
-function isRunexecUnavailableOutput(stdout, stderr) {
+function hasRunexecEnvironmentFailure(stdout, stderr) {
   const text = `${stdout || ''}\n${stderr || ''}`;
-  return RUNEXEC_FALLBACK_PATTERNS.some(pattern => text.includes(pattern));
+  return RUNEXEC_ENV_PATTERNS.some(pattern => text.includes(pattern));
+}
+
+async function readOptionalFile(filePath) {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function inspectRunexecEnvironment() {
+  const issues = [];
+  const mounts = (await readOptionalFile('/proc/mounts')) || '';
+  const mountLine = mounts.split(/\r?\n/).find(line => line.split(' ')[1] === '/sys/fs/cgroup');
+
+  let mountType = null;
+  let mountOptions = null;
+  if (!mountLine) {
+    issues.push('/sys/fs/cgroup is not mounted inside the container.');
+  } else {
+    const parts = mountLine.split(' ');
+    mountType = parts[2] || '';
+    mountOptions = parts[3] || '';
+    if (mountType !== 'cgroup2') {
+      issues.push(`/sys/fs/cgroup is mounted as '${mountType}', expected cgroup2.`);
+    }
+    if (!mountOptions.split(',').includes('rw')) {
+      issues.push(`/sys/fs/cgroup is mounted read-only with options '${mountOptions}'.`);
+    }
+  }
+
+  const controllersRaw = (await readOptionalFile('/sys/fs/cgroup/cgroup.controllers')) || '';
+  const controllers = controllersRaw.trim().split(/\s+/).filter(Boolean);
+  if (!controllers.length) {
+    issues.push('Cannot read any controllers from /sys/fs/cgroup/cgroup.controllers.');
+  }
+
+  for (const controller of REQUIRED_CONTROLLERS) {
+    if (!controllers.includes(controller)) {
+      issues.push(`Required controller '${controller}' is missing from /sys/fs/cgroup/cgroup.controllers.`);
+    }
+  }
+
+  const requiredPaths = [
+    ['/sys/fs/cgroup/cgroup.subtree_control', 'root subtree control file'],
+    ['/sys/fs/cgroup/init/cgroup.procs', 'init cgroup.procs'],
+    ['/sys/fs/cgroup/benchexec/cgroup.subtree_control', 'benchexec subtree control file']
+  ];
+  for (const [targetPath, label] of requiredPaths) {
+    try {
+      await fs.access(targetPath, fsSync.constants.W_OK);
+    } catch (error) {
+      issues.push(`${label} is not writable (${targetPath}): ${error.message}`);
+    }
+  }
+
+  const enabledRaw = (await readOptionalFile('/sys/fs/cgroup/benchexec/cgroup.subtree_control')) || '';
+  const enabledControllers = enabledRaw.trim().split(/\s+/).filter(Boolean);
+  for (const controller of REQUIRED_CONTROLLERS) {
+    if (controllers.includes(controller) && !enabledControllers.includes(controller)) {
+      issues.push(`Controller '${controller}' is not enabled in /sys/fs/cgroup/benchexec/cgroup.subtree_control.`);
+    }
+  }
+
+  return {
+    issues,
+    mountType,
+    mountOptions,
+    controllers,
+    enabledControllers
+  };
+}
+
+function buildRunexecEnvironmentMessage(diag, extraIssues = []) {
+  const issues = [...diag.issues, ...extraIssues].filter(Boolean);
+  const uniqueIssues = [...new Set(issues)];
+  const lines = ['BenchExec cgroup environment is not ready.'];
+  for (const issue of uniqueIssues) {
+    lines.push(`- ${issue}`);
+  }
+  lines.push(`- ${RUNEXEC_HINT}`);
+  return lines.join('\n');
+}
+
+function buildRunexecEnvironmentError(diag, extraIssues = [], stdout = '', stderr = '') {
+  const error = new Error(buildRunexecEnvironmentMessage(diag, extraIssues));
+  error.name = 'RunexecEnvironmentError';
+  error.code = 'RUNEXEC_ENV_INVALID';
+  error.stdout = stdout;
+  error.stderr = stderr;
+  error.diagnostics = diag;
+  return error;
+}
+
+async function assertRunexecEnvironment() {
+  const diag = await inspectRunexecEnvironment();
+  if (diag.issues.length > 0) {
+    throw buildRunexecEnvironmentError(diag);
+  }
+  return diag;
 }
 
 function memMbToArg(memoryMB) {
@@ -56,14 +161,10 @@ async function runWithRunexec({
 }) {
   const runexecPath = path.join(PROJECT_ROOT, 'benchexec', 'bin', 'runexec');
   const pythonBin = process.env.PYTHON_BIN || 'python3';
+  const diag = await assertRunexecEnvironment();
 
   const ra = [];
-  // Prefer container mode. Allow override via env.
-  const noContainer = process.env.RUNEXEC_NO_CONTAINER === '1';
-  if (noContainer) {
-    ra.push('--no-container');
-  }
-  // Container-friendly directory model (harmless in no-container mode)
+  // Always use BenchExec container mode. The service should fail fast if cgroups are unavailable.
   ra.push('--read-only-dir', '/');
   ra.push('--hidden-dir', '/run');
   
@@ -104,25 +205,20 @@ async function runWithRunexec({
   } catch (error) {
     stdout = error.stdout || '';
     stderr = error.stderr || '';
-    if (isRunexecUnavailableOutput(stdout, stderr)) {
-      const fallbackError = new Error('runexec is unavailable in the current container environment');
-      fallbackError.code = 'RUNEXEC_UNAVAILABLE';
-      fallbackError.stdout = stdout;
-      fallbackError.stderr = stderr;
-      throw fallbackError;
+    if (hasRunexecEnvironmentFailure(stdout, stderr)) {
+      const extraIssues = [];
+      if (`${stdout}\n${stderr}`.includes('Operation not permitted')) {
+        extraIssues.push('Kernel namespace creation was denied by the current container privileges.');
+      }
+      throw buildRunexecEnvironmentError(diag, extraIssues, stdout, stderr);
     }
     throw error;
   }
 
   const parsed = parseRunexecResult(stdout);
   if ((parsed.terminationreason === 'failed' || parsed.terminationreason === 'killed')
-      && isRunexecUnavailableOutput(stdout, stderr)) {
-    const fallbackError = new Error('runexec is unavailable in the current container environment');
-    fallbackError.code = 'RUNEXEC_UNAVAILABLE';
-    fallbackError.stdout = stdout;
-    fallbackError.stderr = stderr;
-    fallbackError.parsed = parsed;
-    throw fallbackError;
+      && hasRunexecEnvironmentFailure(stdout, stderr)) {
+    throw buildRunexecEnvironmentError(diag, [], stdout, stderr);
   }
 
   return { stdout, stderr, parsed };

--- a/server/tool-runner.js
+++ b/server/tool-runner.js
@@ -49,6 +49,7 @@ async function executeTool(toolId, regexBase64, timeoutMs, { cpuAllocator, cpuCo
   let parsedOutput = null;
   let rawOutput = null;
   let allocated = null;
+  let runexecFallbackLogs = [];
 
   try {
     if (cpuAllocator && Number.isFinite(cpuCores) && cpuCores > 0) {
@@ -57,24 +58,44 @@ async function executeTool(toolId, regexBase64, timeoutMs, { cpuAllocator, cpuCo
 
     const useRunexec = process.env.DISABLE_RUNEXEC !== '1';
     if (useRunexec) {
-      const r = await runWithRunexec({
-        cmd: file,
-        args,
-        cwd: options.cwd,
-        env: options.env || {},
-        outputLogPath: programOutputPath,
-        timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-        walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-        memoryMB,
-        cores: allocated?.cores
-      });
-      // Program output is redirected to programOutputPath
       try {
-        stdout = await fs.readFile(programOutputPath, 'utf8');
-      } catch {
-        stdout = '';
+        await runWithRunexec({
+          cmd: file,
+          args,
+          cwd: options.cwd,
+          env: options.env || {},
+          outputLogPath: programOutputPath,
+          timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+          walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+          memoryMB,
+          cores: allocated?.cores
+        });
+        // Program output is redirected to programOutputPath
+        try {
+          stdout = await fs.readFile(programOutputPath, 'utf8');
+        } catch {
+          stdout = '';
+        }
+        stderr = '';
+      } catch (error) {
+        if (error.code !== 'RUNEXEC_UNAVAILABLE') {
+          throw error;
+        }
+        runexecFallbackLogs = [
+          ...error.stdout ? [{ stream: 'stderr', content: clampLog(error.stdout) }] : [],
+          ...error.stderr ? [{ stream: 'stderr', content: clampLog(error.stderr) }] : []
+        ];
+
+        const execOptions = {
+          cwd: options.cwd,
+          env: { ...process.env, ...(options.env || {}) },
+          timeout: timeoutMs,
+          maxBuffer: 20 * 1024 * 1024
+        };
+        const result = await execFile(file, args, execOptions);
+        stdout = result.stdout || '';
+        stderr = result.stderr || '';
       }
-      stderr = '';
     } else {
       const execOptions = {
         cwd: options.cwd,
@@ -120,7 +141,8 @@ async function executeTool(toolId, regexBase64, timeoutMs, { cpuAllocator, cpuCo
     stderr,
     parsedOutput,
     rawOutput,
-    durationMs: Date.now() - start
+    durationMs: Date.now() - start,
+    runexecFallbackLogs
   };
 }
 
@@ -159,6 +181,7 @@ async function runToolsJob(jobManager, job, { regex, toolIds, timeoutMs, cpuAllo
         output: result.parsedOutput,
         rawOutput: result.rawOutput,
         logs: [
+          ...result.runexecFallbackLogs,
           ...result.stdout ? [{ stream: 'stdout', content: clampLog(result.stdout) }] : [],
           ...result.stderr ? [{ stream: 'stderr', content: clampLog(result.stderr) }] : []
         ]

--- a/server/tool-runner.js
+++ b/server/tool-runner.js
@@ -1,12 +1,8 @@
 const fs = require('fs/promises');
 const os = require('os');
 const path = require('path');
-const util = require('util');
-const childProcess = require('child_process');
 
-const execFile = util.promisify(childProcess.execFile);
-
-const { TOOL_DEFINITIONS, DEFAULT_OPTIONS } = require('./definitions');
+const { TOOL_DEFINITIONS } = require('./definitions');
 const { runWithRunexec } = require('./runexec');
 
 const LOG_LIMIT = 4000;
@@ -49,64 +45,30 @@ async function executeTool(toolId, regexBase64, timeoutMs, { cpuAllocator, cpuCo
   let parsedOutput = null;
   let rawOutput = null;
   let allocated = null;
-  let runexecFallbackLogs = [];
 
   try {
     if (cpuAllocator && Number.isFinite(cpuCores) && cpuCores > 0) {
       allocated = await cpuAllocator.acquire(cpuCores);
     }
 
-    const useRunexec = process.env.DISABLE_RUNEXEC !== '1';
-    if (useRunexec) {
-      try {
-        await runWithRunexec({
-          cmd: file,
-          args,
-          cwd: options.cwd,
-          env: options.env || {},
-          outputLogPath: programOutputPath,
-          timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-          walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
-          memoryMB,
-          cores: allocated?.cores
-        });
-        // Program output is redirected to programOutputPath
-        try {
-          stdout = await fs.readFile(programOutputPath, 'utf8');
-        } catch {
-          stdout = '';
-        }
-        stderr = '';
-      } catch (error) {
-        if (error.code !== 'RUNEXEC_UNAVAILABLE') {
-          throw error;
-        }
-        runexecFallbackLogs = [
-          ...error.stdout ? [{ stream: 'stderr', content: clampLog(error.stdout) }] : [],
-          ...error.stderr ? [{ stream: 'stderr', content: clampLog(error.stderr) }] : []
-        ];
-
-        const execOptions = {
-          cwd: options.cwd,
-          env: { ...process.env, ...(options.env || {}) },
-          timeout: timeoutMs,
-          maxBuffer: 20 * 1024 * 1024
-        };
-        const result = await execFile(file, args, execOptions);
-        stdout = result.stdout || '';
-        stderr = result.stderr || '';
-      }
-    } else {
-      const execOptions = {
-        cwd: options.cwd,
-        env: { ...process.env, ...(options.env || {}) },
-        timeout: timeoutMs,
-        maxBuffer: 20 * 1024 * 1024
-      };
-      const result = await execFile(file, args, execOptions);
-      stdout = result.stdout || '';
-      stderr = result.stderr || '';
+    await runWithRunexec({
+      cmd: file,
+      args,
+      cwd: options.cwd,
+      env: options.env || {},
+      outputLogPath: programOutputPath,
+      timelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+      walltimelimitSeconds: timeoutMs ? Math.floor(timeoutMs / 1000) : undefined,
+      memoryMB,
+      cores: allocated?.cores
+    });
+    // Program output is redirected to programOutputPath
+    try {
+      stdout = await fs.readFile(programOutputPath, 'utf8');
+    } catch {
+      stdout = '';
     }
+    stderr = '';
 
     rawOutput = await fs.readFile(outputPath, 'utf8');
     parsedOutput = JSON.parse(rawOutput);
@@ -141,8 +103,7 @@ async function executeTool(toolId, regexBase64, timeoutMs, { cpuAllocator, cpuCo
     stderr,
     parsedOutput,
     rawOutput,
-    durationMs: Date.now() - start,
-    runexecFallbackLogs
+    durationMs: Date.now() - start
   };
 }
 
@@ -181,7 +142,6 @@ async function runToolsJob(jobManager, job, { regex, toolIds, timeoutMs, cpuAllo
         output: result.parsedOutput,
         rawOutput: result.rawOutput,
         logs: [
-          ...result.runexecFallbackLogs,
           ...result.stdout ? [{ stream: 'stdout', content: clampLog(result.stdout) }] : [],
           ...result.stderr ? [{ stream: 'stderr', content: clampLog(result.stderr) }] : []
         ]


### PR DESCRIPTION
## Summary
- require BenchExec cgroups for the web service and remove all runexec fallback paths
- fail fast with explicit startup/runtime diagnostics when cgroups v2 are unavailable or misconfigured
- document the required `--privileged --cgroupns=host` startup mode for the dashboard

## What changed
- `init.sh` now validates writable cgroups v2 before starting the web service and exits with a concrete fatal message when the environment is wrong
- `server/runexec.js` now inspects the cgroup environment, reports specific problems, and throws `RUNEXEC_ENV_INVALID` instead of silently degrading
- `server/tool-runner.js` and `server/engine-runner.js` always use `runexec`; no direct-exec fallback remains
- `README.md` and `DEPLOYMENT.md` now document the strict startup requirement and expected failure mode

## Validation
- built the image successfully and started the service with `--privileged --cgroupns=host`
- verified tool and engine jobs complete under strict `runexec`
- verified non-privileged startup fails explicitly with logs like:
  - `FATAL: BenchExec requires writable cgroups v2 inside the container.`
  - `FATAL: /sys/fs/cgroup is mounted read-only ...`
- `./quick_verify.sh` still passes
